### PR TITLE
Fix OAuth state handling and clean extension code

### DIFF
--- a/echo-escape-extension/popup.js
+++ b/echo-escape-extension/popup.js
@@ -1,25 +1,5 @@
-// Final popup.js
-
-
 const API_URL = 'https://outoftheloop.duckdns.org';
 const DASHBOARD_URL = 'https://out-of-the-loop.netlify.app';
-// Called by platform.js once it loads
-window.onGoogleLibraryLoad = function () {
-    // render into the div that our renderLoginForm will inject
-    gapi.signin2.render('google-signin-button', {
-        scope: 'profile email',
-        width: 240,
-        longtitle: true,
-        theme: 'light',
-        onsuccess: onGoogleSignIn
-    });
-};
-
-// Called by Google when the user signs in
-window.onGoogleSignIn = function (googleUser) {
-    const idToken = googleUser.getAuthResponse().id_token;
-    // … your existing fetch to /login/google etc …
-};
 
 // This is the main function that runs when the popup is opened
 document.addEventListener('DOMContentLoaded', function () {
@@ -128,8 +108,6 @@ function renderResults(container, analysisData) {
         handleSave(analysisData);
     });
 }
-// In popup.js
-
 function renderLoginForm(container) {
     container.innerHTML = `
         <h3>Login</h3>
@@ -175,7 +153,9 @@ function renderLoginForm(container) {
     });
     document.getElementById('google-login-button').addEventListener('click', (e) => {
         e.preventDefault();
-        chrome.tabs.create({ url: `${API_URL}/login/google?state=extension` });
+        const state = `${crypto.randomUUID()}|extension`;
+        const authUrl = `${API_URL}/login/google?state=${encodeURIComponent(state)}`;
+        chrome.tabs.create({ url: authUrl });
         container.innerHTML = `<div style="text-align: center; padding: 20px;"><p>Waiting for Google Sign-In...</p></div>`;
     });
 }

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders login button', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const buttonElement = screen.getByRole('button', { name: /login/i });
+  expect(buttonElement).toBeInTheDocument();
 });

--- a/frontend/src/AuthComponent.js
+++ b/frontend/src/AuthComponent.js
@@ -22,6 +22,11 @@ export default function AuthComponent({ onAuth }) {
     } catch (err) { setError(err.message); }
   };
 
+  const handleGoogleLogin = () => {
+    const state = `${crypto.randomUUID()}|dashboard`;
+    window.location.href = `${process.env.REACT_APP_API_URL}/login/google?state=${encodeURIComponent(state)}`;
+  };
+
   return (
     <div style={styles.card}>
       <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
@@ -43,7 +48,7 @@ export default function AuthComponent({ onAuth }) {
         <button type="submit" style={styles.button}>{mode === 'login' ? 'Login' : 'Sign Up'}</button>
       </form>
       <div style={{ textAlign: 'center', margin: '15px 0', color: '#666', fontWeight: 'bold' }}>OR</div>
-      <a href={`${process.env.REACT_APP_API_URL}/login/google?state=dashboard`} className="google-btn">
+      <a href="#" onClick={handleGoogleLogin} className="google-btn">
         <div className="google-icon-wrapper">
           <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 48 48">
             <g>


### PR DESCRIPTION
## Summary
- remove legacy Google One Tap hooks and generate UUID-based OAuth state in the extension
- add matching UUID state handling in dashboard login
- streamline backend Google OAuth routes and use new extension ID

## Testing
- `python -m py_compile backend/app.py`
- `cd frontend && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68914d43739c8332ac7a00b3d4da71b6